### PR TITLE
Drop bundler as development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.0)
   norma43_parser!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/lib/norma43/version.rb
+++ b/lib/norma43/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Norma43
-  VERSION = "2.1.1"
+  VERSION = "2.2.1"
 end

--- a/norma43_parser.gemspec
+++ b/norma43_parser.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "virtus",   "~> 1.0"
   spec.add_runtime_dependency "zeitwerk", "~> 2.0"
 
-  spec.add_development_dependency "bundler", "~> 1.0"
   spec.add_development_dependency "rake",    "~> 13.0"
   spec.add_development_dependency "rspec",   "~> 3.0"
 end


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-fp4w-jxhp-m23p and https://github.com/advisories/GHSA-g98m-96g9-wfjq vulnerabilities alerts

## Proposed Changes

- Drop `bundler` from development dependencies
