### PR TITLE
Increase required ruby version to >= 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 3.0.0 (2021-12-15)
+
+### Breaking Changes
+
+- Drop Ruby support below 2.6.
+
+### Bug fixes
+
+-
+
+### Enhancements
+
+-
+
 ## 2.1.1 (2020-03-13)
 
 ### Breaking Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    norma43_parser (2.2.1)
+    norma43_parser (3.0.0)
       virtus (~> 1.0)
       zeitwerk (~> 2.0)
 

--- a/lib/norma43/version.rb
+++ b/lib/norma43/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Norma43
-  VERSION = "2.2.1"
+  VERSION = "3.0.0"
 end

--- a/norma43_parser.gemspec
+++ b/norma43_parser.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sequra/norma43_parser"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
To drop support for ruby versions older than 2.6 and to create a new release