### PR TITLE
gemspec: Drop unused "executables" directive

### DIFF
--- a/norma43_parser.gemspec
+++ b/norma43_parser.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION


## Proposed Changes

This gem exposes no `executables`. We can drop the setting in the gemspec.
