### PR TITLE
Get ibans from account instances

### DIFF
--- a/lib/norma43/models.rb
+++ b/lib/norma43/models.rb
@@ -46,6 +46,59 @@ module Norma43
       attribute :credit_entries
       attribute :credit_amount
       attribute :transactions, Array[Transaction]
+
+      def iban
+        return nil if [bank_code, branch_code, account_number].any?(&:nil?)
+        return @iban unless @iban.nil?
+        country_code = "ES"
+        country_number = country_code.chars.map { |char| char.to_i(36) }.join
+        ccc = calculate_ccc(bank_code.to_i, branch_code.to_i, account_number.to_i)
+        number_to_checksum = "#{ccc}#{country_number}00".to_i
+        international_checksum = calculate_iban_checksum_number(number_to_checksum)
+
+        @iban = sprintf("%{country_code}%<checksum_number>02d%{ccc}",
+          country_code: country_code,
+          checksum_number: international_checksum,
+          ccc: ccc)
+      end
+
+      private
+        def calculate_ccc(bank_code, branch_code, account_number)
+          bank_with_branch_number = (bank_code * 10**4) + branch_code
+
+          bank_with_branch_check_digit, account_number_check_digit = [
+            bank_with_branch_number,
+            account_number
+          ].map { |number| calculate_spanish_checksum_digit(number) }
+
+          checksum_number = bank_with_branch_check_digit * 10 + account_number_check_digit
+
+          sprintf("%<bank_code>04d%<branch_code>04d%<checksum_number>02d%<account_number>010d",
+            bank_code: bank_code,
+            branch_code: branch_code,
+            checksum_number: checksum_number,
+            account_number: account_number)
+        end
+
+        def calculate_spanish_checksum_digit(number)
+          modulus = 11
+          # Sorted by order of magnitude: units, tens, hundreds, thousands, etc.
+          digit_weights = [6, 3, 7, 9, 10, 5, 8, 4, 2, 1].freeze
+
+          reminder = digit_weights.map.with_index { |weight, order_of_magnitude|
+            digit_at_position = (number / 10**order_of_magnitude) % 10
+
+            digit_at_position * weight
+          }.sum % modulus
+
+          return reminder if reminder.zero? || reminder == 1
+          modulus - reminder
+        end
+
+        def calculate_iban_checksum_number(number)
+          modulus = 97
+          (modulus + 1) - (number % modulus)
+        end
     end
 
     class Transaction

--- a/spec/example1_parse_spec.rb
+++ b/spec/example1_parse_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Norma43 do
           "end_date"              => Date.parse("2004-09-05"),
           "currency_code"         => 1,
           "information_mode_code" => 3,
-          "abbreviated_name"      => "MY ACCOUNT"
+          "abbreviated_name"      => "MY ACCOUNT",
+          "iban"                  => "ES1799991111710123456789",
         )
       end
 

--- a/spec/norma43/models/account_spec.rb
+++ b/spec/norma43/models/account_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Norma43
+  module Models
+    RSpec.describe Account do
+      describe "IBAN requirements" do
+        it "responds to attributes needed to calculate the IBAN number" do
+          is_expected.to(respond_to(:bank_code)
+            .and respond_to(:branch_code)
+            .and respond_to(:account_number)
+          )
+        end
+
+        it "responds to IBAN" do
+          is_expected.to(respond_to(:iban))
+        end
+      end
+
+      describe "#iban" do
+        subject(:iban) { described_class.new(attributes).iban }
+
+        context "with missing bank code" do
+          let(:attributes) { { "bank_code" => nil, "branch_code" => 1111, "account_number" => 123456789 } }
+          it { is_expected.to be_nil }
+        end
+
+        context "with missing branch code" do
+          let(:attributes) { { "bank_code" => 9999, "branch_code" => nil, "account_number" => 123456789 } }
+          it { is_expected.to be_nil }
+        end
+
+        context "with missing account number" do
+          let(:attributes) { { "bank_code" => 9999, "branch_code" => 1111, "account_number" => nil } }
+          it { is_expected.to be_nil }
+        end
+
+        context "with complete attributes" do
+          let(:attributes) { { "bank_code" => 81, "branch_code" => 54, "account_number" => 1234567 } }
+          it { is_expected.to eq("ES5400810054180001234567") }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes nothing, this is a new feature.

## Proposed Changes

- To query payments by IBAN and be able to audit or verify against the actual bank statements, we need to save the IBAN during the N43 file import process (aka bank transfer reconcilation)
- `Norma43::Models::Account` instances have all the information they need to return the IBAN. The only thing stopping us from implementing it was to program the needed checksum calculations (one for the middle of the CCC and another for the international part after the country code `ESxx`). These two are publicly documented
  1. CCC: https://code.google.com/archive/p/checkdigits/wikis/CheckDigitSystems.wiki in section **ISO 7064 Mod 97,10**
  2. IBAN: https://en.wikipedia.org/wiki/International_Bank_Account_Number
